### PR TITLE
1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
 ## 1.0.2
-*   **Pluralization:** Ensured proper pluralization for long format units.
-*   **Documentation:** Clarified usage instructions and examples in the README.
-*   **Typo:** Fix typo in `Unit.zetabyte` -> `Unit.zettabyte`
+*   **Pluralization:** Fixed pluralization for long-format units (e.g., "2 megabytes" instead of "2 megabyte").
+*   **Typo:** Corrected `Unit.zetabyte` to `Unit.zettabyte`.
+*   **README:** Minor clarifications to usage instructions and examples.
 
 ## 1.0.1
-- Update package description
+*   **Docs:** Improved package description for pub.dev.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2
+*   **Pluralization:** Ensured proper pluralization for long format units.
+*   **Documentation:** Clarified usage instructions and examples in the README.
+*   **Typo:** Fix typo in `Unit.zetabyte` -> `Unit.zettabyte`
+
 ## 1.0.1
 - Update package description
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 **A self-contained Dart library for seamlessly converting between bytes and human-readable file sizes.**
 
-Effortlessly convert raw byte values into human-readable file sizes like "1.2 KB" or "3.5 MB", and vice versa. This is ideal for displaying file sizes in user interfaces, handling file uploads, processing data storage information, and more. Supports both binary (KiB, MiB, GiB) and metric (KB, MB, GB) units.
+Effortlessly convert raw byte values into human-readable file sizes like "1.2 KB" or "3.5 MB", and vice versa.
+
+This is ideal for displaying file sizes in user interfaces, handling file uploads, processing data storage information, and more.
+
+Supports both binary (KiB, MiB, GiB) and metric (KB, MB, GB) units.
 
 ## Features
 
@@ -26,7 +30,7 @@ Or, manually add it to your project's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  proper_filesize: ^1.0.0
+  proper_filesize: ^1.0.2
 ```
 
 Then run:
@@ -76,14 +80,14 @@ import 'package:proper_filesize/proper_filesize.dart';
 int bytes = 1243560000;
 
 // Using metric units (KB, MB, GB)
-String metricFilesize = FileSize(bytes).toString(
+String metricFilesize = FileSize.fromBytes(bytes).toString(
   unit: Unit.auto(size: bytes, baseType: BaseType.metric),
 );
 print("$bytes bytes is $metricFilesize"); 
 // Output: 1243560000 bytes is 1.244 GB
 
 // Using binary units (KiB, MiB, GiB)
-String binaryFilesize = FileSize(bytes).toString();
+String binaryFilesize = FileSize.fromBytes(bytes).toString();
 print("$bytes bytes is $binaryFilesize"); 
 // Output: 1243560000 bytes is 1.158 GiB
 ```

--- a/example/example.dart
+++ b/example/example.dart
@@ -50,7 +50,7 @@ void main() {
   );
   print(
     "$bytes bytes is $metricFilesizeLong",
-  ); // 1243560000 bytes is 1.244 gigabyte
+  ); // 1243560000 bytes is 1.244 gigabytes
 
   // Generate a binary unit string with the full unit name ("gibibyte")
   final String binaryFilesizeLong = FileSize.fromBytes(bytes).toString(
@@ -59,7 +59,7 @@ void main() {
   );
   print(
     "$bytes bytes is $binaryFilesizeLong",
-  ); // 1243560000 bytes is 1.158 gibibyte
+  ); // 1243560000 bytes is 1.158 gibibytes
 
   // Generate a string with the explicit unit "gigabyte"
   final String explicitUnitFilesize =

--- a/lib/src/file_size.dart
+++ b/lib/src/file_size.dart
@@ -74,8 +74,12 @@ final class FileSize {
         ? value.toInt().toString()
         : value.toStringAsFixed(decimals));
     final String unitStr = unit.representation[formatType]!;
+    final String pluralUnit = switch (formatType) {
+      FormatType.long when value != 1 => "s",
+      _ => "",
+    };
 
-    return "$valueStr $unitStr";
+    return "$valueStr $unitStr$pluralUnit";
   }
 
   /// Returns the size in the specified [unit].

--- a/lib/src/unit.dart
+++ b/lib/src/unit.dart
@@ -75,8 +75,8 @@ enum Unit {
     },
   ),
 
-  /// The zetabyte unit.
-  zetabyte(
+  /// The zettabyte unit.
+  zettabyte(
     orderOfMagnitude: 7,
     baseType: BaseType.metric,
     representation: <FormatType, String>{
@@ -173,8 +173,7 @@ enum Unit {
       FormatType.short: "YiB",
       FormatType.long: "yobibyte",
     },
-  ),
-  ;
+  );
 
   /// Creates a [Unit] object.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: proper_filesize
 description: Standalone file size conversion and formatting library. Generate human-readable output for UIs. Supports metric/binary units (KB, KiB, MB, MiB, etc.)
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/gilnobrega/proper_filesize
 
 environment:

--- a/test/file_size_test.dart
+++ b/test/file_size_test.dart
@@ -151,6 +151,23 @@ void main() {
     });
 
     test('''
+        SHOULD return "5 megabytes" 
+        WHEN filesize is 5000000 bytes and formatType is long
+        ''', () {
+      // Arrange
+      const int bytes = 5000000;
+
+      // Act
+      final String result = FileSize.fromBytes(bytes).toString(
+        unit: Unit.auto(size: bytes, baseType: BaseType.metric),
+        formatType: FormatType.long,
+      );
+
+      // Assert
+      expect(result, "5 megabytes");
+    });
+
+    test('''
         SHOULD return "1 kibibyte" 
         WHEN filesize is 1024 bytes and formatType is long
         ''', () {


### PR DESCRIPTION
This is a hotfix release addressing minor issues and improving usability.

**Fixes:**

*   **Pluralization:** Fixed pluralization for long-format units (e.g., "2 megabytes" instead of "2 megabyte").
*   **Typo:** Corrected `Unit.zetabyte` to `Unit.zettabyte`.
*   **README:** Minor clarifications to usage instructions and examples.